### PR TITLE
Update _post.scss

### DIFF
--- a/assets/css/components/_post.scss
+++ b/assets/css/components/_post.scss
@@ -3,7 +3,6 @@
 }
 
 .post-meta > div {
-  display: flex;
   align-items: center;
   font-size: 0.8em;
 


### PR DESCRIPTION
Fix missing capability to  wrap tag list to the next line which becomes an issue in small browser windows (e.g. mobile device)

Not fixed:
<img width="965" alt="image" src="https://github.com/flo-kn/hugo-theme-m10c/assets/104433967/ac832c72-e731-4353-8aae-19af333ba237">


Fixed:
<img width="978" alt="image" src="https://github.com/flo-kn/hugo-theme-m10c/assets/104433967/6ce03859-e9bb-4889-b397-a451aeff5d3f">
